### PR TITLE
Adds notebook CIDR SG port 80 ingress for plot retrieval

### DIFF
--- a/hail-emr.yml
+++ b/hail-emr.yml
@@ -557,6 +557,11 @@ Resources:
           ToPort: 8998
           CidrIp: !Ref pLivyIngressCidr
           Description: "Livy Access"
+        - IpProtocol: "tcp"
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref pLivyIngressCidr
+          Description: "HTTP for notebook Hail plot retrieval"
         - IpProtocol: "-1"
           FromPort: -1
           ToPort: -1


### PR DESCRIPTION
Hail plots can be saved on the master node and retrieved by
the notebook server via HTTP request.  The template `pIngressCidr`
already allowed this access, but there are cases where the ingress CIDR
may not overlap with the notebook CIDR.  This covers that use case.