### PR TITLE
Limiting the maximum size of the root volume too 100GB, which is the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ venv.bak/
 .vscode
 
 packer/packer.zip
+.idea

--- a/hail-emr.yml
+++ b/hail-emr.yml
@@ -104,7 +104,8 @@ Parameters:
   pEmrInstanceRootVolSize:
     Default: "100"
     Description: "Required - GB.  Root volume size for ALL cluster instances."
-    MinValue: "60"
+    MaxValue: "100"
+    MinValue: "10"
     Type: "Number"
 
   pEmrInstanceTerminationProtection:


### PR DESCRIPTION
…max allowed by EMR