### PR TITLE
Hail AMIs, documentation, and cluster tuning

### DIFF
--- a/hail-emr.yml
+++ b/hail-emr.yml
@@ -5,7 +5,7 @@ Description: "EMR with Hail and VEP"
 Parameters:
 
   pAmi:
-    Description: "Required - packer built in the local account"
+    Description: "Required - Packer built in the local account, or use public AMI from repo"
     Type: "AWS::EC2::Image::Id"
 
   pAllowSsmShell:

--- a/hail-emr.yml
+++ b/hail-emr.yml
@@ -332,7 +332,8 @@ Parameters:
       - "emr-5.26.0"
       - "emr-5.27.0"
       - "emr-5.28.0"
-    Default: "emr-5.28.0"
+      - "emr-5.29.0"
+    Default: "emr-5.29.0"
     Description: "Required"
     Type: "String"
 
@@ -551,6 +552,12 @@ Resources:
             - Classification: "export"
               ConfigurationProperties:
                 PYSPARK_PYTHON: "/usr/bin/python3"
+        - Classification: "yarn-site"
+          ConfigurationProperties:
+            yarn.log-aggregation.retain-seconds: "3600"
+        - Classification: "emrfs-site"
+          ConfigurationProperties:
+            fs.s3.maxConnections: "200"
       CustomAmiId: !Ref pAmi
       EbsRootVolumeSize: !Ref pEmrInstanceRootVolSize
       Instances:
@@ -698,7 +705,7 @@ Resources:
           - Action:
               SimpleScalingPolicyConfiguration:
                 AdjustmentType: "CHANGE_IN_CAPACITY"
-                CoolDown: 300
+                CoolDown: 900
                 ScalingAdjustment: -2
             Description: "Remove 2 instances when YARN available memory > 75%"
             Name: "yarnMemoryUseLow"
@@ -708,12 +715,12 @@ Resources:
                 Dimensions:
                   - Key: "JobFlowId"
                     Value: !Ref cluster
-                EvaluationPeriods: 1
+                EvaluationPeriods: 3
                 MetricName: "YARNMemoryAvailablePercentage"
                 Namespace: "AWS/ElasticMapReduce"
                 Period: 300
                 Statistic: "AVERAGE"
-                Threshold: 0.75
+                Threshold: 80
                 Unit: "PERCENT"
       InstanceCount: !Ref pEmrMinTaskNodeCount
       InstanceRole: "TASK"

--- a/hail-jupyter.yml
+++ b/hail-jupyter.yml
@@ -193,7 +193,7 @@ Resources:
               # sudo chown "ec2-user":"ec2-user" $DIRECTORY --recursive
 
               # Use the system AWS, since ec2-user may change conda environments
-              CMD="/usr/bin/aws s3 sync $DIRECTORY s3://$BUCKET/${pName}/ > /home/ec2-user/s3-backup.log 2>&1"
+              CMD="/usr/bin/aws s3 sync --exclude 'bin/*' --exclude '.sparkmagic/*' --exclude '*.ipynb_checkpoints/*' $DIRECTORY s3://$BUCKET/${pName}/ > /home/ec2-user/s3-backup.log 2>&1"
               chown "ec2-user":"ec2-user" $DIRECTORY --recursive
               # Backup the notebook details to S3 on 5 minute intervals
               cronjob="*/5 * * * * $CMD"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Hail on EMR
 
-This repository contains resources for repeatable deployments of [Hail](https://hail.is) on AWS EMR and an [AWS Sagemaker](https://aws.amazon.com/sagemaker/faqs) notebook instance configuration to interaction with the Hail cluster.
+This repository contains resources for repeatable deployments of [Hail](https://hail.is) on AWS EMR and an [AWS Sagemaker](https://aws.amazon.com/sagemaker/faqs) notebook instance configuration to interact with the Hail cluster.
 
 ## Table of Contents
 
@@ -54,6 +54,8 @@ Post upload, the bucket contents should look similar to this:
 2019-09-30 14:14:36       1244 scripts/list-clusters
 2019-09-30 14:14:36       1244 scripts/ssm
 ```
+
+It is recommended that this template be deployed in the same subnet as your EMR cluster.
 
 ### hail-ami
 

--- a/readme.md
+++ b/readme.md
@@ -4,18 +4,20 @@ This repository contains resources for repeatable deployments of [Hail](https://
 
 ## Table of Contents
 
-- [CloudFormation Templates](#cloudformation-templates)
-  - [hail-s3](#hail-s3)
-  - [hail-jupyter](#hail-jupyter)
-  - [hail-ami](#hail-ami)
-  - [hail-emr](#hail-emr)
-    - [Autoscaling Task Nodes](#autoscaling-task-nodes)
-    - [Plotting](#plotting)
-    - [SSM Access](#ssm-access)
-- [Deployment Order](#deployment-order)
-- [Public AMIs](#public-amis)
-  - [Hail with VEP](#hail-with-vep)
-  - [Hail Only](#hail-only)
+- [Hail on EMR](#hail-on-emr)
+  - [Table of Contents](#table-of-contents)
+  - [CloudFormation Templates](#cloudformation-templates)
+    - [hail-s3](#hail-s3)
+    - [hail-jupyter](#hail-jupyter)
+    - [hail-ami](#hail-ami)
+    - [hail-emr](#hail-emr)
+      - [Autoscaling Task Nodes](#autoscaling-task-nodes)
+      - [Plotting](#plotting)
+      - [SSM Access](#ssm-access)
+  - [Deployment Order](#deployment-order)
+  - [Public AMIs](#public-amis)
+    - [Hail with VEP](#hail-with-vep)
+    - [Hail Only](#hail-only)
 
 ## CloudFormation Templates
 
@@ -75,7 +77,7 @@ The following scaling actions are set by default:
 
 - +2 instances when YARNMemoryAvailablePercentage < 15 % over 5 min
 - +2 instances when ContainerPendingRatio > .75 over 5 min
-- -2 instances when YARNMemoryAvailablePercentage > 75 % over 5 min
+- -2 instances when YARNMemoryAvailablePercentage > 80 % over 15 min
 
 #### Plotting
 
@@ -108,6 +110,9 @@ Public AMIs are available in specific regions. Select the AMI for your target re
 
 | Region    | Hail Version | VEP Version | EMR Version | AMI ID                |
 |:---------:|:------------:|:-----------:|:-----------:|:--------------------: |
+| us-east-1 | 0.2.31       | 99          | 5.29.0      | ami-0f51d75d56c8469f7 |
+| us-east-2 | 0.2.31       | 99          | 5.29.0      | ami-0ddba7b9f36e79d47 |
+| us-west-2 | 0.2.31       | 99          | 5.29.0      | ami-0af36d6360120ea35 |
 | us-east-1 | 0.2.29       | 98          | 5.28.0      | ami-0b016dfca524fec33 |
 | us-east-2 | 0.2.29       | 98          | 5.28.0      | ami-082b3c5dadecc4a87 |
 | us-west-2 | 0.2.29       | 98          | 5.28.0      | ami-0aa2d49e3149759e9 |
@@ -122,6 +127,9 @@ Public AMIs are available in specific regions. Select the AMI for your target re
 
 | Region    | Hail Version | EMR Version | AMI ID                |
 |:---------:|:------------:|:-----------:|:--------------------: |
+| us-east-1 | 0.2.31       | 5.29.0      | ami-00fbbaf3c6ca73c57 |
+| us-east-2 | 0.2.31       | 5.29.0      | ami-0daa264e629449221 |
+| us-west-2 | 0.2.31       | 5.29.0      | ami-07fc30be8fe168cdb |
 | us-east-1 | 0.2.29       | 5.28.0      | ami-05e440db5d3e3bcba |
 | us-east-2 | 0.2.29       | 5.28.0      | ami-064ce48aad3e10749 |
 | us-west-2 | 0.2.29       | 5.28.0      | ami-0d8c99d07ae2ebc5b |


### PR DESCRIPTION
Hail 0.2.31 with optional VEP 99 AMIs

Sagemaker
- Exclude bin directory and "dot" directories from S3 backup sync
- Document notebook instance should be in same subnet as cluster.   This prevents connectivity issues that may arise from different subnets each with their own route tables.

YARN
- Logs purged from HDFS after 1 hour.   These are still available in S3.   Prevents YARN node blacklisting due to HDFS at capacity from Livy logs

EMRFS
- S3 max connections raised from default 50 to 200. 

Autoscaling
- Scale down metric correction and slower cooldown.   Prevents cluster scale down before containers have exited.